### PR TITLE
セッション設定項目にsave_handlerを追加

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -98,6 +98,7 @@ define('ATTR_SELECTED', 'selected="selected"');
 
 // セッション設定
 define('DIR_TEMP', './temp');
+ini_set('session.save_handler', 'files');
 session_name('TRANSMITMAILSESSID');
 session_save_path(DIR_TEMP);
 session_set_cookie_params(0, DIR_MAILFORM, $_SERVER['HTTP_HOST']);


### PR DESCRIPTION
デフォルトでファイルがhandlerじゃない場合があり、エラーが発生したため。
