### PR TITLE
ログファイルの存在確認に未定義の変数が使われているのを修正

### DIFF
--- a/lib/common.php
+++ b/lib/common.php
@@ -408,7 +408,7 @@ function is_log_file($file_name) {
 		$i = 1;
 		$num = '_' . $i;
 		$log_file = $file_name . $num;
-		while (is_file($result)) {
+		while (is_file($log_file)) {
 			$i++;
 			$num = '_' . $i;
 			$log_file = $file_name . $num;


### PR DESCRIPTION
whileに未定義の変数`$result`が使われていました。
おそらく常に`false`になり、想定していない動きに思えたので、
while内の意図を汲み、`$log_file`に変更してみました。