### PR TITLE
checkDenyHostの$this->serversを$this->serverに修正

### DIFF
--- a/lib/TransmitMail.php
+++ b/lib/TransmitMail.php
@@ -349,8 +349,8 @@ class TransmitMail
         if (!empty($this->config['deny_host'])) {
             $pattern = '/\A' . $this->config['deny_host'] . '\z/';
 
-            if (preg_match($pattern, $this->servers['REMOTE_ADDR']) ||
-                preg_match($pattern, $this->servers['REMOTE_HOST'])) {
+            if (preg_match($pattern, $this->server['REMOTE_ADDR']) ||
+                preg_match($pattern, $this->server['REMOTE_HOST'])) {
                 $this->deny_flag = true;
             }
         }


### PR DESCRIPTION
`deny_host`configを設定し、[checkDenyHost](https://github.com/dounokouno/TransmitMail/blob/master/lib/TransmitMail.php#L344-L357)を呼び出すと以下のエラーがでます。

```
PHP Notice:  Undefined property: TransmitMail::$servers in /TransmitMail-master/lib/TransmitMail.php on line 352
PHP Notice:  Undefined property: TransmitMail::$servers in /TransmitMail-master/lib/TransmitMail.php on line 353

```

原因は、
[getRequestで$this->serverに代入しているのに](https://github.com/dounokouno/TransmitMail/blob/master/lib/TransmitMail.php#L329)、
[checkDenyHostでは$this->serversを参照している](https://github.com/dounokouno/TransmitMail/blob/master/lib/TransmitMail.php#L352-L353)
ことだと思われます。