### PR TITLE
未定義の定数をconfigのエラーメッセージへ変更

### DIFF
--- a/lib/TransmitMail.php
+++ b/lib/TransmitMail.php
@@ -791,8 +791,8 @@ class TransmitMail
                                     );
                                 } else {
                                     // アップロードに失敗した場合
-                                    $file_error[] = $this->h($key . ERROR_FILE_UPLOAD);
-                                    $this->global_errors[] = $this->h($key . ERROR_FILE_UPLOAD);
+                                    $file_error[] = $this->h($key . $this->config['error_file_upload']);
+                                    $this->global_errors[] = $this->h($key . $this->config['error_file_upload']);
                                     $this->tpl->set("file.$key", $file_error);
                                 }
                             }


### PR DESCRIPTION
ファイルアップロードに失敗した場合のエラーメッセージの定数`ERROR_FILE_UPLOAD`が未定義に見えます。
おそらくv1時の[config.php](https://github.com/dounokouno/TransmitMail/blob/8207ef50af7e5df8fd9e0e291df5c6f595a1e1f8/conf/config.php#L157)の名残では無いかと考えています。
ファイルを編集し、無理矢理実行した場合には

```
PHP Notice:  Use of undefined constant ERROR_FILE_UPLOAD - assumed 'ERROR_FILE_UPLOAD' in /TransmitMail-master/lib/TransmitMail.php on line xxx
PHP Notice:  Use of undefined constant ERROR_FILE_UPLOAD - assumed 'ERROR_FILE_UPLOAD' in /TransmitMail-master/lib/TransmitMail.php on line xxx
```

とstringの`'ERROR_FILE_UPLOAD'`で処理されるはずですが、こちらはおそらく意図していないのではないかと思っています。
なので、他のメッセージと同じく`$this->config`のエラーメッセージを出力するように変更しました。

ファイルのアップロード失敗は発生頻度がかなり低いと思われますし、影響も軽微なのですが、
確認お願いいたします。