### PR TITLE
Fix "Array to string conversion" warning on PHP 8.2+

### DIFF
--- a/lib/TransmitMail.php
+++ b/lib/TransmitMail.php
@@ -624,7 +624,7 @@ class TransmitMail
             $this->post[$this->config['auto_reply_email_input_name']] = $this->deleteCrlf($this->post[$this->config['auto_reply_email_input_name']]);
 
             if (!$this->isEmail($this->post[$this->config['auto_reply_email_input_name']])) {
-                $this->tpl->set("email.$this->config['auto_reply_email_input_name']", $this->h($this->config['auto_reply_email_input_name'] . $this->config['error_email']));
+                $this->tpl->set("email.{$this->config['auto_reply_email_input_name']}", $this->h($this->config['auto_reply_email_input_name'] . $this->config['error_email']));
 
                 if (!in_array($this->h($this->config['auto_reply_email_input_name'] . $this->config['error_email']), $this->global_errors, true)) {
                     $this->global_errors[] = $this->h($this->config['auto_reply_email_input_name'] . $this->config['error_email']);


### PR DESCRIPTION
PHP 8.2 以降でメールアドレスの書式チェックを行った際、`log/error.log` に下記の警告が発生していたため、変数（オブジェクトプロパティの配列要素）を中括弧で囲むよう修正しました。


```
[09-Sep-2025 15:00:00 Asia/Tokyo] PHP Warning:  Array to string conversion in /var/www/html/contact/lib/TransmitMail.php on line 627
```